### PR TITLE
impr: add isOptionalField value into check function in args

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,25 +1,32 @@
 interface IRule {
-    validator: Function;
-    message: string;
+  validator: Function;
+  message: string;
+  optional?: boolean;
 }
 interface IFieldsAndRules {
-    field: string;
-    rules: IRule[];
+  field: string;
+  rules: IRule[];
 }
 interface ICheck {
-    field: string;
-    message: string;
+  field: string;
+  message: string;
 }
+
+interface ICheckObj {
+  [key: string]: any
+  isOptionalField?: boolean
+}
+
 declare class RequestCheck {
-    rules: any;
-    requiredMessage: string;
-    useFieldNameAsKey: boolean;
-    constructor();
-    setRequiredMessage: (message: string) => void;
-    addRule: (field: string, ...rules: IRule[]) => void;
-    addRules: (field: string, rules: IRule[]) => void;
-    addFieldsAndRules: (fieldsAndRules: IFieldsAndRules[]) => void;
-    check: (...args: Array<any>) => Array<ICheck> | any | undefined;
+  rules: any;
+  requiredMessage: string;
+  useFieldNameAsKey: boolean;
+  constructor();
+  setRequiredMessage: (message: string) => void;
+  addRule: (field: string, ...rules: IRule[]) => void;
+  addRules: (field: string, rules: IRule[]) => void;
+  addFieldsAndRules: (fieldsAndRules: IFieldsAndRules[]) => void;
+  check: (...args: Array<ICheckObj>) => Array<ICheck> | any | undefined;
 }
 declare const requestCheck: () => RequestCheck;
 export default requestCheck;

--- a/index.test.ts
+++ b/index.test.ts
@@ -327,3 +327,53 @@ test('it uses field name as key', () => {
   
   
 })
+
+test('it should pass if is an optional field', () => {
+  const rc = requestCheck()
+
+  rc.requiredMessage = 'The field :name is required!'
+  rc.useFieldNameAsKey = true
+
+  rc.addFieldsAndRules([{
+    field: 'age', 
+    rules: [{ 
+      validator: (age: number) => age > 23, 
+      message: 'The age must be above 23!' 
+    }]
+  }])
+  
+  const requestBody: any = {
+    age: undefined  
+  }
+
+  const { age } = requestBody
+
+  const invalid = rc.check({ age, isOptionalField: true })
+  
+  expect(invalid).toBeUndefined()
+})
+
+test('it should return an error if is required field', () => {
+  const rc = requestCheck()
+
+  rc.requiredMessage = 'The field :name is required!'
+  rc.useFieldNameAsKey = true
+
+  rc.addFieldsAndRules([{
+    field: 'age', 
+    rules: [{ 
+      validator: (age: number) => age > 23, 
+      message: 'The age must be above 23!' 
+    }]
+  }])
+  
+  const requestBody: any = {
+    age: undefined  
+  }
+
+  const { age } = requestBody
+
+  const invalid = rc.check({ age, isOptionalField: false })
+  
+  expect(invalid).toEqual([{ 'age':'The field age is required!'}])
+})

--- a/index.ts
+++ b/index.ts
@@ -87,9 +87,13 @@ class RequestCheck {
       const label = field?.[0]
       const value = field?.[1]
 
-      const isRequired = !isOptionalField && (value === undefined || value === null)
+      const isMissing = [undefined, null].includes(value)
 
-      if (isRequired) {
+      if (isOptionalField && isMissing) {
+        continue
+      }
+
+      if (isMissing) {
         const invalidField = this.buildInvalidField({ value, field: label, message: this.requiredMessage, })
         invalid.push(invalidField)
         continue

--- a/index.ts
+++ b/index.ts
@@ -14,7 +14,14 @@ interface ICheck {
 }
 
 interface ICheckObj {
-  [key: string]: string
+  [key: string]: any
+  isOptionalField?: boolean
+}
+
+interface IInvalidField { 
+  value: any 
+  field: any 
+  message: string 
 }
 
 const isEmptyObject = (object: any) => Object.keys(object).length === 0 && object.constructor === Object
@@ -56,33 +63,51 @@ class RequestCheck {
       this.addRules(fieldAndRule.field, fieldAndRule.rules)
     }
   }
-  
-  check = (...args: Array<any>): Array<ICheck> | any | undefined => {
+
+  buildInvalidField = ({ value, field, message }: IInvalidField) => {
+    if (this.useFieldNameAsKey) {
+      return { [field]: message.replace(':name', field).replace(':field', field).replace(':value', value) }
+    }
+    
+    return {
+      field,
+      message: message.replace(':name', field).replace(':field', field).replace(':value', value)
+    }
+  }
+
+  check = (...args: Array<ICheckObj>): Array<ICheck> | any | undefined => {
     let invalid: Array<ICheck> | any = []
     while(args.length) {
       let object = args.shift()
-      if(!object || !isObject(object) || isEmptyObject(object)) continue
-      let field = Object.keys(object)[0], value = object[field]
-      if(!value && value !== false && value !== 0) {
-        this.useFieldNameAsKey ?
-          invalid.push({ 
-            [field]: this.requiredMessage
-            .replace(':name', field).replace(':field', field).replace(':value', value)
-          }) : invalid.push({ 
-            field, message: this.requiredMessage
-            .replace(':name', field).replace(':field', field).replace(':value', value)
-          })
+      if (!object || !isObject(object) || isEmptyObject(object)) continue
+      const entries = Object.entries(object)
+      const isOptionalField = [true].includes(entries?.find(([entry]) => entry === 'isOptionalField')?.[1])
+
+      const field = entries?.find(([entry]) => entry !== 'isOptionalField')
+      const label = field?.[0]
+      const value = field?.[1]
+
+      const isRequired = !isOptionalField && (value === undefined || value === null)
+
+      if (isRequired) {
+        const invalidField = this.buildInvalidField({ value, field: label, message: this.requiredMessage, })
+        invalid.push(invalidField)
+        continue
       }
-      else if(field in this.rules) {
-        let array = [ ...this.rules[field]]
+
+      if (label && label in this.rules) {
+        const array = this.rules[label]
+
         while(array.length) {
           let validation = array.shift()
           if(!validation.validator(value)) {
-            this.useFieldNameAsKey ? invalid.push({ [field]: validation.message }) : invalid.push({ field, message: validation.message})
+            const invalidField = this.buildInvalidField({ value, field: label, message: validation.message })
+            invalid.push(invalidField)
           }
         }
       }
     }
+
     return invalid.length ? invalid : undefined
   }
 }


### PR DESCRIPTION
## Why create a isOptionalField in check arggs? 
To my team (cof), we use this package a lot and is worst to our code use a ternary to do a optional values. In addition, you create a possibility to make the code bring more errors (leaving decision to other programmers). 

## Add a buildInvalidField function, why?
I see a duplication of code in it and i just try to clean, It's not too good but it's something,