### PR TITLE
Improvement: Change isOptionalField to isRequiredField

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,12 +113,12 @@ Using empty object `{}` instead of `undefined` will work as well.
 
 Sometimes we want to validate a value if it is given, withouth making it required**.
 
-We can use as shown above `age ? {age} : undefined` or you can use **isOptionalField**
+We can use as shown above `age ? {age} : undefined` or you can use **isRequiredField**
 
 Example:
 
 ```javascript
-  const invalid = rc.check({ age, isOptionalField: true })
+  const invalid = rc.check({ age, isRequiredField: false })
 ```
 
 This will trigger `age` validation _only_ if `age` is given.

--- a/index.test.ts
+++ b/index.test.ts
@@ -332,7 +332,6 @@ test('it should pass if is an optional field', () => {
   const rc = requestCheck()
 
   rc.requiredMessage = 'The field :name is required!'
-  rc.useFieldNameAsKey = true
 
   rc.addFieldsAndRules([{
     field: 'age', 
@@ -343,12 +342,12 @@ test('it should pass if is an optional field', () => {
   }])
   
   const requestBody: any = {
-    age: undefined  
+    age: ''  
   }
 
   const { age } = requestBody
 
-  const invalid = rc.check({ age, isOptionalField: true })
+  const invalid = rc.check({ age, isRequiredField: false })
   
   expect(invalid).toBeUndefined()
 })
@@ -357,7 +356,6 @@ test('it should return an error if is required field', () => {
   const rc = requestCheck()
 
   rc.requiredMessage = 'The field :name is required!'
-  rc.useFieldNameAsKey = true
 
   rc.addFieldsAndRules([{
     field: 'age', 
@@ -373,7 +371,8 @@ test('it should return an error if is required field', () => {
 
   const { age } = requestBody
 
-  const invalid = rc.check({ age, isOptionalField: false })
+  const invalid = rc.check({ age, isRequiredField: true })
   
-  expect(invalid).toEqual([{ 'age':'The field age is required!'}])
+  expect(invalid).toEqual([{ field: 'age', message: 'The field age is required!' }])
+
 })

--- a/index.test.ts
+++ b/index.test.ts
@@ -374,5 +374,4 @@ test('it should return an error if is required field', () => {
   const invalid = rc.check({ age, isRequiredField: true })
   
   expect(invalid).toEqual([{ field: 'age', message: 'The field age is required!' }])
-
 })

--- a/index.ts
+++ b/index.ts
@@ -15,7 +15,7 @@ interface ICheck {
 
 interface ICheckObj {
   [key: string]: any
-  isOptionalField?: boolean
+  isRequiredField?: boolean
 }
 
 interface IInvalidField { 
@@ -81,13 +81,13 @@ class RequestCheck {
       let object = args.shift()
       if (!object || !isObject(object) || isEmptyObject(object)) continue
       const entries = Object.entries(object)
-      const isOptionalField = [true].includes(entries?.find(([entry]) => entry === 'isOptionalField')?.[1])
+      const isOptionalField = [false].includes(entries?.find(([entry]) => entry === 'isRequiredField')?.[1])
 
-      const field = entries?.find(([entry]) => entry !== 'isOptionalField')
+      const field = entries?.find(([entry]) => entry !== 'isRequiredField')
       const label = field?.[0]
       const value = field?.[1]
 
-      const isMissing = [undefined, null].includes(value)
+      const isMissing = [undefined, null, ''].includes(value)
 
       if (isOptionalField && isMissing) {
         continue


### PR DESCRIPTION
That change it is important to keep our code more readable, because is strange to read a property with inverted name like "isOptinalField". 
When you read a prop, you must waiting for a positive name, what that prop can do.