### PR TITLE
Impr/i18n configuration for required message

### DIFF
--- a/README.md
+++ b/README.md
@@ -378,6 +378,27 @@ The return format depends on whether the i18n property is present:
 
 > ⚠️ Important: The return format only changes for `useFieldNameAsKey = true` when `i18n` property is defined. Otherwise, the return remains a simple string containing the error message.
 
+#### Change default required message with i18n
+
+To enable automatic translation of required messages, you can attach i18n configuration objects:
+
+```tsx
+// Method 1: Using setter with i18n
+rc.setRequiredMessage(
+  'This field is required', // Fallback message
+  { 
+    key: 'validation.required', 
+    options: { } // Dynamic variables
+  }
+)
+
+// Method 2: Direct property assignment
+rc.i18nRequiredMessage = {
+  key: 'validation.requiredField',
+  options: { }
+}
+```
+
 ## Advanced
 
 ### Why arguments are separated as objects?

--- a/README.md
+++ b/README.md
@@ -394,18 +394,18 @@ rc.setRequiredMessage(
 
 // Method 2: Direct property assignment
 rc.i18nRequiredMessage = {
-  key: 'validation.requiredField',
+  key: 'validation.required',
   options: { }
 }
 
 ```
 Both methods will add into output:
-```json
+```tsx
 {
-  "field": "name",
-  "message": "This field is required",
-  "i18n": { // <--- //Added
-    "key": "validation.required"
+  field: 'name',
+  message: 'This field is required',
+  i18n: { // <--- //Added
+    key: 'validation.required'
   }
 }
 ```

--- a/README.md
+++ b/README.md
@@ -378,17 +378,17 @@ The return format depends on whether the i18n property is present:
 
 > ⚠️ Important: The return format only changes for `useFieldNameAsKey = true` when `i18n` property is defined. Otherwise, the return remains a simple string containing the error message.
 
-#### Change default required message with i18n
+#### Using requiredMessage with i18n
 
-To enable automatic translation of required messages, you can attach i18n configuration objects:
+To include i18n configuration in `requiredMessage` output, set the `i18nRequiredMessage` property with a key and options for the translation.
 
 ```tsx
 // Method 1: Using setter with i18n
 rc.setRequiredMessage(
-  'This field is required', // Fallback message
+  'This field is required',
   { 
     key: 'validation.required', 
-    options: { } // Dynamic variables
+    options: { }
   }
 )
 
@@ -396,6 +396,17 @@ rc.setRequiredMessage(
 rc.i18nRequiredMessage = {
   key: 'validation.requiredField',
   options: { }
+}
+
+```
+Both methods will add into output:
+```json
+{
+  "field": "name",
+  "message": "This field is required",
+  "i18n": { // <--- //Added
+    "key": "validation.required"
+  }
 }
 ```
 

--- a/index.test.ts
+++ b/index.test.ts
@@ -9,7 +9,8 @@ const i18nKeys : Record<string, string> = {
   'rules.test.invalidId': 'The value {{value}} is not a valid id! - I was translated!',
   'rules.test.nameMustBeAString': 'Name must be a string! - I was translated!',
   'rules.test.invalidName': 'Your name must be a string - I was translated!',
-  'rules.test.invalidNameField': '{{field}} must be a string, but the value {{value}} is not valid for {{name}} - I was translated!'
+  'rules.test.invalidNameField': '{{field}} must be a string, but the value {{value}} is not valid for {{name}} - I was translated!',
+  'rules.required.message': 'The field {{name}} is required! - I was translated!'
 }
 
 test('it validates as expected', () => {
@@ -972,6 +973,45 @@ test('it should translate with useFieldNameAsKey configuration activated and add
           }
         }
       }
+    }
+  ])
+})
+
+test('it should use requiredMessage with i18n', () => {
+  const rc = requestCheck()
+
+  rc.setRequiredMessage('The field :name is required!', { key: 'rules.required.message' })
+
+  const requestBody: any = {
+    age: undefined  
+  }
+  const age = requestBody.age
+
+  const invalid = rc.check({ age })
+  const ageField = invalid[0]
+
+  // It simulates the translation process
+  expect(invalid).toEqual([
+    { 
+      field: "age",
+      message: "The field age is required!",
+      i18n: {
+        key: 'rules.required.message',
+        options: { name: 'age'}
+      }
+    }
+  ])
+
+  const translatedMessage = i18nKeys[ageField.i18n.key]
+      .replace('{{name}}', ageField.i18n.options?.name)
+
+  ageField.message = translatedMessage
+  delete ageField.i18n
+
+  expect(invalid).toEqual([
+    { 
+      field: "age",
+      message: "The field age is required! - I was translated!"
     }
   ])
 })

--- a/index.test.ts
+++ b/index.test.ts
@@ -977,10 +977,50 @@ test('it should translate with useFieldNameAsKey configuration activated and add
   ])
 })
 
-test('it should use requiredMessage with i18n', () => {
+test('it should use requiredMessage with i18n using setRequiredMessage setter', () => {
   const rc = requestCheck()
 
   rc.setRequiredMessage('The field :name is required!', { key: 'rules.required.message' })
+
+  const requestBody: any = {
+    age: undefined  
+  }
+  const age = requestBody.age
+
+  const invalid = rc.check({ age })
+  const ageField = invalid[0]
+
+  // It simulates the translation process
+  expect(invalid).toEqual([
+    { 
+      field: "age",
+      message: "The field age is required!",
+      i18n: {
+        key: 'rules.required.message',
+        options: { name: 'age'}
+      }
+    }
+  ])
+
+  const translatedMessage = i18nKeys[ageField.i18n.key]
+      .replace('{{name}}', ageField.i18n.options?.name)
+
+  ageField.message = translatedMessage
+  delete ageField.i18n
+
+  expect(invalid).toEqual([
+    { 
+      field: "age",
+      message: "The field age is required! - I was translated!"
+    }
+  ])
+})
+
+test('it should use requiredMessage with i18n using i18nRequiredMessage property attribution', () => {
+  const rc = requestCheck()
+
+  rc.requiredMessage = 'The field :name is required!'
+  rc.i18nRequiredMessage = { key: 'rules.required.message' }
 
   const requestBody: any = {
     age: undefined  

--- a/index.ts
+++ b/index.ts
@@ -56,6 +56,7 @@ class RequestCheck {
 
   rules: any
   requiredMessage: string
+  i18nRequiredMessage?: II18nMessage
   useFieldNameAsKey: boolean
 
   constructor() {
@@ -68,8 +69,9 @@ class RequestCheck {
     this.rules = {}
   }
 
-  setRequiredMessage = (message: string) => {
+  setRequiredMessage = (message: string, i18n?: II18nMessage) => {
     this.requiredMessage = message
+    if(i18n) this.i18nRequiredMessage = i18n
   }
 
   addRule = (field: string, ...rules: IRule[]) => {
@@ -145,7 +147,7 @@ class RequestCheck {
       }
 
       if (isMissing) {
-        const invalidField = this.buildInvalidField({ value, field: label, message: this.requiredMessage, })
+        const invalidField = this.buildInvalidField({ value, field: label, message: this.requiredMessage, i18n: this.i18nRequiredMessage })
         invalid.push(invalidField)
         continue
       }


### PR DESCRIPTION
Extends the required message system with i18n configuration support, allowing validation messages to have i18n object in output

Example:
```
{
  "field": "statusId",
  "message": "Required field!"
  "i18n": {
    "key": { 'validation.requiredField' } 
  }
}
```

This PR is a improvement of feat/i18n-support update

## 🧪 Tests added

- Test using setRequiredMessage('message', { key: 'someKey' }) setter with second parameter 
- Test using i18nRequiredMessage property attribution 

<img width="258" height="125" alt="image" src="https://github.com/user-attachments/assets/01ab4a51-6584-4ddf-8155-1b208a025771" />

## Coveralls

<img width="535" height="195" alt="image" src="https://github.com/user-attachments/assets/4e5cb69a-26eb-49f0-bdf5-3ad1cbd18ee2" />
